### PR TITLE
docs: added `bluesky_post`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 ### Other Tools
 
 - [twitter-to-bsky](https://github.com/ianklatzco/twitter-to-bsky) Import a Twitter archive into Bluesky. (may spam timeline!)
+- [bluesky-post](https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_post) A tool to post from GitHub Actions to Bluesky Social on your behalf.
+  - site: [GitHub Marketplace](https://github.com/marketplace/actions/send-bluesky-post)


### PR DESCRIPTION
Hi,

I have added a tool to the documentation that allows people to post on their behalf from GitHub Actions to Bluesky Social.

This tool is mainly for developers, but I believe it can be used to notify users from GitHub Actions when an app is released, and etc.