### PR TITLE
Add Bsky Tooling to "Other Tools" section along with additional clarification/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 
 ### Web Clients
 
-- Bluesky:
+- Bluesky (developed by Bluesky PBLLC):
   - site: [https://staging.bsky.app/](https://staging.bsky.app/)
 - Flat:
   - app: [flat-bs.vercel.app](https://flat-bs.vercel.app)
@@ -60,7 +60,7 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 
 - Bluesky (developed by Bluesky PBLLC)
   - app: [App Store](https://apps.apple.com/us/app/bluesky-social/id6444370199)
-  - site: [bsky.app](bsky.app)
+  - site: [bsky.app](https://bsky.app)
 
 ### CLI Clients
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 - Bsky
   - app: [bsky.syui.cf](https://bsky.syui.cf)
   - repo: [github.com/syui/bsky-web](https://github.com/syui/bsky-web)
-- Bsky Wrapper (view-only)
+- Bsky Wrapper
   - site: [blue.amazingca.dev](https://blue.amazingca.dev)
   - repo: [https://github.com/Amazingca/BSKY-Wrapper](https://github.com/Amazingca/BSKY-Wrapper)
 - Skylight
@@ -59,6 +59,7 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 ### iOS Clients
 
 - Bluesky (developed by Bluesky PBLLC)
+  - app: [App Store](https://apps.apple.com/us/app/bluesky-social/id6444370199)
   - site: [bsky.app](bsky.app)
 
 ### CLI Clients
@@ -74,3 +75,6 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 ### Other Tools
 
 - [twitter-to-bsky](https://github.com/ianklatzco/twitter-to-bsky) Import a Twitter archive into Bluesky. (may spam timeline!)
+- Bsky Tooling – Cache and follow tons of repos and users.
+  - site: [blue.amazingca.dev/tools](https://blue.amazingca.dev/tools)
+  - repo: [https://github.com/Amazingca/BSKY-Wrapper/blob/main/tools.html](https://github.com/Amazingca/BSKY-Wrapper/blob/main/tools.html)


### PR DESCRIPTION
Edit overview:

Line \#28
Add "(developed by Bluesky PBLLC)" so others know this web app is official.

Line \#36
Remove "(view-only)" indication due to feature implementation.

Line \#62-63
Add iOS App Store link for easy accessibility and fix "bsky.app" link redirect.

Line \#78-80
Add Bsky Tooling in the "Other Tools" section, which allows the viewer to pull a cache of most repos and users. It also allows for bulk user following.