### PR TITLE
Add blue-sky-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 - bluesky_cli (Dart)
   - repo: [bluesky_cli](https://github.com/myConsciousness/atproto.dart/tree/main/packages/bluesky_cli)
   - site: [pub.dev](https://pub.dev/packages/bluesky_cli)
+- [blue-sky-cli](https://github.com/wesbos/blue-sky-cli) (Typescript)
 
 ### Other Tools
 


### PR DESCRIPTION
Add the BlueSky CLI from Wes Bos, a typescript CLI app to view the feed and posts.

- [blue-sky-cli](https://github.com/wesbos/blue-sky-cli)