### PR TITLE
Add Skylink - Web extension to discover profiles linked to a website domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
   - [Mozilla Add-ons](https://addons.mozilla.org/en-US/firefox/addon/bluesky-overhaul/)
 - [SkyLink](https://github.com/jessejanderson/skylink) A simple web extension that detects if the current website is connected to a Bluesky user.
   - [Chrome Web Store](https://chrome.google.com/webstore/detail/skylink-bluesky-did-detec/aflpfginfpjhanhkmdpohpggpolfopmb)
+  - [Mozilla Add-ons](https://addons.mozilla.org/en-US/firefox/addon/skylink-bluesky-did-detector/)
 - [granary](https://granary.io/) (Python, REST API) converts `app.bsky` objects to/from ActivityStreams, RSS, Atom, HTML, and more
 - [Bridgy Fed](https://fed.brid.gy/) (Python) includes implementations of the [AT Protocol Merkle search tree](https://github.com/snarfed/bridgy-fed/blob/main/atproto_mst.py) and [`com.atproto.sync`](https://github.com/snarfed/bridgy-fed/blob/main/atproto.py)
 - [bsky-link-preview](https://github.com/capjamesg/bsky-link-preview): Generate an embeddable link preview for a Bluesky post.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 - [Bluesky Overhaul](https://github.com/xenohunter/bluesky-overhaul) Browser extension that improves UX on the web app
   - [Chrome Web Store](https://chrome.google.com/webstore/detail/bluesky-overhaul/cllpkmbebfmadmkkpplnaaffnhjjpgbi)
   - [Mozilla Add-ons](https://addons.mozilla.org/en-US/firefox/addon/bluesky-overhaul/)
+- [SkyLink](https://github.com/jessejanderson/skylink) A simple web extension that detects if the current website is connected to a Bluesky user.
+  - [Chrome Web Store](https://chrome.google.com/webstore/detail/skylink-bluesky-did-detec/aflpfginfpjhanhkmdpohpggpolfopmb)
 - [granary](https://granary.io/) (Python, REST API) converts `app.bsky` objects to/from ActivityStreams, RSS, Atom, HTML, and more
 - [Bridgy Fed](https://fed.brid.gy/) (Python) includes implementations of the [AT Protocol Merkle search tree](https://github.com/snarfed/bridgy-fed/blob/main/atproto_mst.py) and [`com.atproto.sync`](https://github.com/snarfed/bridgy-fed/blob/main/atproto.py)
 - [bsky-link-preview](https://github.com/capjamesg/bsky-link-preview): Generate an embeddable link preview for a Bluesky post.


### PR DESCRIPTION
@jessejanderson put together a web extension called SkyLink that shows if a website you're visiting has any associated AT protocol TXT records, and allows you to click through to the discovered protocol. 

Currently available for Chrome, with Firefox support pending an add-on review by Mozilla.