### PR TITLE
Add link to socialweb/atproto-lexicon library

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,4 @@ List of projects and implementations in the AT protocol ecosystem. Many are WIP,
 - [granary](https://granary.io/) (Python, REST API) converts `app.bsky` objects to/from ActivityStreams, RSS, Atom, HTML, and more
 - [Bridgy Fed](https://fed.brid.gy/) (Python) includes implementations of the [AT Protocol Merkle search tree](https://github.com/snarfed/bridgy-fed/blob/main/atproto_mst.py) and [`com.atproto.sync`](https://github.com/snarfed/bridgy-fed/blob/main/atproto.py)
 - [bsky-link-preview](https://github.com/capjamesg/bsky-link-preview): Generate an embeddable link preview for a Bluesky post.
+- [socialweb/atproto-lexicon](https://github.com/socialweb-php/atproto-lexicon) (PHP, Lexicon parser): Parses and resolves Lexicon schemas; useful for code generation and more.


### PR DESCRIPTION
This library is a Lexicon schema parser for PHP applications/tools/libraries: https://github.com/socialweb-php/atproto-lexicon